### PR TITLE
refactor: use platform helpers to set defaults

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,8 +12,6 @@
 
   outputs =
     { self
-    , nixpkgs
-    , nix-darwin
     , flake-parts
     , ...
     }@inputs:
@@ -26,7 +24,7 @@
       perSystem = { pkgs, system, ... }:
         let
           tests = import ./tests/setup.nix {
-            inherit pkgs inputs system;
+            inherit self pkgs inputs system;
           };
 
           docs = import ./docs {

--- a/targets/darwin.nix
+++ b/targets/darwin.nix
@@ -1,18 +1,18 @@
-{ config, pkgs, ... }:
-
-let
-  script = pkgs.writeShellScript "plist-darwin-activate" config.plist.out;
-  fail = msg: "(printf '\\033[0;31m${msg}\\033[0m\n' && exit 1)";
-in
+{ config, ... }:
 
 {
   imports = [
     ../modules
   ];
 
+  system.defaults.CustomUserPreferences = config.plist.out;
+
   system.activationScripts.postActivation.text = ''
     echo "Activating plistManager"
-    echo "└── Using ${script}"
-    ${script} || ${fail "Failed to run ${script}"}
+
+    ${config.plist.purgeScript}
+
+    # Reload settings
+    /System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
   '';
 }

--- a/targets/home-manager.nix
+++ b/targets/home-manager.nix
@@ -1,17 +1,17 @@
-{ config, pkgs, lib, ... }:
-
-let
-  script = pkgs.writeShellScript "plist-home-activate" config.plist.out;
-  fail = msg: "(printf '\\033[0;31m${msg}\\033[0m\n' && exit 1)";
-in
+{ config, lib, ... }:
 
 {
   imports = [
     ../modules
   ];
 
+  targets.darwin.defaults = config.plist.out;
+
   home.activation.plistManager = lib.hm.dag.entryAfter [ "setDarwinDefaults" ] ''
-    echo "└── Using ${script}"
-    run ${script} || ${fail "Failed to run ${script}"}
+    set -e
+    ${config.plist.purgeScript}
+
+    # Reload settings
+    /System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
   '';
 }


### PR DESCRIPTION
Replace our internal logic in favor of using nix-darwin's `system.defaults.CustomUserPreferences` or home-manager's `targets.darwin.defaults`.

We still take care of deletion as usual. Nothing changed functionality-wise.

Why?
- Less logic to maintain
- Slightly easier to spot conflicts e.g. if a user sets a value with plist-manager and a different one with `system.defaults.CustomUserPreferences` nix should catch that during build.